### PR TITLE
Add --step option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Options for "up" and "down":
   --to, -t    Migrate upto (downto) specific version
   --from, -f  Start migration from specific version
   --only, -o  Migrate only specific version
+  --step, -s  Limit the number of migrations to apply
 
 Global options:
   --cwd         Specify the working directory
@@ -55,12 +56,15 @@ Global options:
 As a convenience, you can skip --to flag, and just provide migration name.
 
 Examples
-  $ knex-migrate up                  # migrate everytings
-  $ knex-migrate up 20160905         # migrate upto given migration name
+  $ knex-migrate up                  # migrate to the latest version
+  $ knex-migrate up 20160905         # migrate to a specific version
   $ knex-migrate up --to 20160905    # the same as above
-  $ knex-migrate up --only 201609085 # migrate up single migration
+  $ knex-migrate up --only 201609085 # apply a single migration, skipping prior migrations
+  $ knex-migrate up --step           # apply only the next migration
+  $ knex-migrate up --step 2         # apply only the next two migrations
   $ knex-migrate down --to 0         # rollback all migrations
   $ knex-migrate down                # rollback single migration
+  $ knex-migrate down --step 2       # rollback the previous two migrations
   $ knex-migrate rollback            # rollback previous "up"
   $ knex-migrate redo --verbose      # rollback and migrate everything
 ```

--- a/src/cli.js
+++ b/src/cli.js
@@ -26,6 +26,7 @@ const cli = meow(
     --to, -t    Migrate upto (downto) specific version
     --from, -f  Start migration from specific version
     --only, -o  Migrate only specific version
+    --step, -s  Limit the number of migrations to apply
 
   Global options:
     --cwd         Specify the working directory
@@ -37,12 +38,15 @@ const cli = meow(
   As a convenience, you can skip --to flag, and just provide migration name.
 
   Examples
-    $ knex-migrate up                  # migrate everytings
-    $ knex-migrate up 20160905         # migrate upto given migration name
+    $ knex-migrate up                  # migrate to the latest version
+    $ knex-migrate up 20160905         # migrate to a specific version
     $ knex-migrate up --to 20160905    # the same as above
-    $ knex-migrate up --only 201609085 # migrate up single migration
+    $ knex-migrate up --only 201609085 # apply a single migration, skipping prior migrations
+    $ knex-migrate up --step           # apply only the next migration
+    $ knex-migrate up --step 2         # apply only the next two migrations
     $ knex-migrate down --to 0         # rollback all migrations
     $ knex-migrate down                # rollback single migration
+    $ knex-migrate down --step 2       # rollback the previous two migrations
     $ knex-migrate rollback            # rollback previous "up"
     $ knex-migrate redo --verbose      # rollback and migrate everything
  `,
@@ -50,9 +54,10 @@ const cli = meow(
     alias: {
       to: 't',
       from: 'f',
-      only: 'o'
+      only: 'o',
+      step: 's'
     },
-    string: ['to', 'from', 'only']
+    string: ['to', 'from', 'only', 'step']
   }
 )
 


### PR DESCRIPTION
As discussed in #11, this option can be used to limit the number of migrations applied by `up` and `down` commands.

Has no effect when combined with `--only`.