### PR TITLE
Ensure migrations table before operating on it

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -260,18 +260,21 @@ async function knexMigrate (command, flags, progress) {
       return relative(flags.cwd, name)
     },
     list: async () => {
+      await umzug.storage.ensureTable()
       const migrations = await umzug.executed()
       return migrations.map(m =>
         relative(flags.cwd, resolve(flags.migrations, m.file))
       )
     },
     pending: async () => {
+      await umzug.storage.ensureTable()
       const migrations = await umzug.pending()
       return migrations.map(m =>
         relative(flags.cwd, resolve(flags.migrations, m.file))
       )
     },
     rollback: async () => {
+      await umzug.storage.ensureTable()
       const migrations = await umzug.storage.migrations()
 
       if (migrations.length === 0) {
@@ -285,6 +288,7 @@ async function knexMigrate (command, flags, progress) {
       return umzug.down({ to: firstFromBatch.name })
     },
     redo: async () => {
+      await umzug.storage.ensureTable()
       const history = await umzug.executed()
       const args = {}
       if (history.length > 0) {


### PR DESCRIPTION
Previously we had some operations that were assuming the migrations
table existed before trying to select data out of it. When the table did
not exist, you'd get an error from knex stating as such.

This patch adds code to make sure the table exists before trying to
retrieve data from it.

Closes #17.

I ran out of time to work on this today, so I didn't have time to pull together some form of test for this, but I did verify it fixes the problem.