### PR TITLE
Return empty array from `executed()` when no tbl

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -70,6 +70,13 @@ module.exports = class KnexStorage {
     return this.knex(this.tableName)
       .orderBy('id', 'asc')
       .pluck('name')
+      .catch(err => {
+        if (tableDoesNotExist(err, this.tableName)) {
+          return []
+        }
+
+        throw err
+      })
   }
 
   getCurrentBatch () {


### PR DESCRIPTION
Previously the library was failing with a table missing error when you
run --list or --pending and the migrations table doesn't exist. This
patch gracefully handles the scenario where the table does not exist to
prevent this error.

Closes #17.


**before**
```
example $ rm db/dev.sqlite3 
example $ npm run --silent migrate -- list
select `name` from `knex_migrations` order by `id` asc - SQLITE_ERROR: no such table: knex_migrations
example $ echo $?
1
example $ npm run --silent migrate -- pending
select `name` from `knex_migrations` order by `id` asc - SQLITE_ERROR: no such table: knex_migrations
example $ echo $?
1
```
**after**
```
example $ rm db/dev.sqlite3 
example $ npm run --silent migrate -- list
example $ echo $?
0
example $ npm run --silent migrate -- pending
db/migrations/20170427093232_add_users.js
db/migrations/20170527093232_add_posts.js
db/migrations/20170727093232_add_tags.js
example $ echo $?
0
example $ npm run --silent migrate -- up --step=1
↑ db/migrations/20170427093232_add_users.js
example $ npm run --silent migrate -- list
db/migrations/20170427093232_add_users.js
example $ npm run --silent migrate -- pending
db/migrations/20170527093232_add_posts.js
db/migrations/20170727093232_add_tags.js
```