### PR TITLE
Pass options to minimist

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -64,7 +64,7 @@ function help () {
 }
 
 async function main () {
-  const flags = require('minimist')(process.argv.slice(2))
+  const flags = require('minimist')(process.argv.slice(2), options)
   const input = flags._
 
   if (input.length < 1 && !flags.list) {


### PR DESCRIPTION
We were previously defining options to pass to minimist, but not passing
them in. This patch fixes that.

Fixes #21.