### PR TITLE
Change migrations pattern to accept typescript (.ts) migration script

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,7 @@ function umzugKnex (flags, connection) {
     migrations: {
       params: [connection, Promise],
       path: flags.migrations,
-      pattern: /^\d+[\w-_]+\.js$/,
+      pattern: /^\d+[\w-_]+\.[j|t]s$/,
       wrap: fn => (knex, Promise) => {
         if (flags.raw) {
           return Promise.resolve(fn(knex, Promise))
@@ -236,7 +236,7 @@ async function knexMigrate (command, flags, progress) {
       action,
       migration: relative(
         flags.cwd,
-        resolve(flags.migrations, migration + '.js')
+        resolve(flags.migrations, migration)
       )
     })
   }


### PR DESCRIPTION
I made change to make knex-migrate accept typescript migration script

Change migrations pattern to accept typescript (.ts) migration script
Remove .js extension from migration name output