### PR TITLE
Allow access of Umzug object before running API  methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Examples
 import knexMigrate from 'knex-migrate'
 
 // It has following signature:
-// knexMigrate(command: String, flags: Object, progress: Function)
+// knexMigrate(command: String, flags: Object, progress: Function [, beforeRun: Function])
 
 async function run() {
   // Action can be: migrate, revert. Migration is migration name. For example:
@@ -95,6 +95,13 @@ async function run() {
   await knexMigrate('rollback', {}, log)
   await knexMigrate('redo', {}, log)
   await knexMigrate('down', { to: 0 }, log)
+
+  // You can add a final argument to access umzug before migration execution:
+  await knexMigrate('up', {}, log, function beforeRun(umzug) {
+    umzug.on('migrated', (name, migration) => {
+      // you could seed some data on a given migration, etc...
+    })
+  })
 }
 
 run()

--- a/example/migrate.js
+++ b/example/migrate.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const knexMigrate = require('../package/src')
+const knexMigrate = require('../src')
 
 // It has following signature:
 // knexMigrate(command: String, flags: Object, progress: Function)
@@ -9,6 +9,7 @@ async function run () {
   const log = ({ action, migration }) =>
     console.log('Doing ' + action + ' on ' + migration)
 
+  await knexMigrate('down')
   await knexMigrate('up', { to: '20170727093232' }, log)
   await knexMigrate('down', { step: 2 }, log)
   await knexMigrate('down', { to: 0 }, log)
@@ -17,6 +18,12 @@ async function run () {
   await knexMigrate('rollback', {}, log)
   await knexMigrate('redo', {}, log)
   await knexMigrate('down', { to: 0 }, log)
+
+  await knexMigrate('up', {}, log, umzug => {
+    umzug.on('migrated', (name, migration) => {
+      console.log('Umzug "migrated" event:', name, migration)
+    })
+  })
 }
 
 run().then(

--- a/example/package.json
+++ b/example/package.json
@@ -2,7 +2,7 @@
   "name": "example",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "migrate.js",
   "scripts": {
     "migrate": "node ../package/src/cli.js",
     "programmatic": "node ./migrate.js"
@@ -12,6 +12,6 @@
   "dependencies": {
     "knex": "^0.14.4",
     "knex-migrate": "^1.5.3",
-    "sqlite3": "^3.1.13"
+    "sqlite3": "^4.0.2"
   }
 }


### PR DESCRIPTION
My team has some requirement for extensive migration testing to see how data is affected during up/down phases. We want to seed the data as soon as the table is available for maximum test/data coverage.

This just adds a "beforeRun" argument which would be really helpful for us to use in combination with the seeding logic we have. We can bind directly to Umzug's events and seed on demand.

There don't seem to be any formal tests but I've used (and updated) the example code to add some proof of it working properly.