### PR TITLE
Allow send payload data to migration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - [x] quickly rollback recent migrations
 - [x] redo feature: rollback and migrate again for quick testing
 - [x] runs migrations in transactions
+- [x] allow send data to migration files (payload)
 - [x] friendly ui 🌹
 
 ## Installation
@@ -97,6 +98,39 @@ async function run() {
 }
 
 run()
+```
+
+Example with payload:
+
+```es6
+const flags = {
+  payload: {
+    schemaBranch: 'devel'
+  },
+  config: {
+    client: "postgresql",
+    connection: {
+      host: process.env.PGHOST,
+      port: process.env.PGPORT,
+      database: process.env.PGDATABASE,
+      user: process.env.PGUSER,
+      password: process.env.PGPASSWORD
+    },
+    migrations: {
+      extension: "ts",
+      loadExtensions: [".ts"],
+      directory: "./migrations/data_branch",
+      tableName: `public.migration_branch_devel`,
+    }
+  }
+};
+const result = await knexMigrate('up', flags);
+```
+and migration file:
+```es6
+exports.up = async (knex, promise, payload) => {
+  return knex.raw(`CREATE OR REPLACE VIEW "${payload.schemaBranch}".invoice_type AS SELECT 1`);
+};
 ```
 
 ## Thank you

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ function normalizeFlags (flags) {
     flags.cwd = dirname(flags.migrations)
   }
 
+  flags.payload = flags.payload || null;
   flags.cwd = flags.cwd || process.cwd()
   flags.knexfile = flags.knexfile || 'knexfile.js'
 
@@ -115,9 +116,9 @@ function umzugKnex (flags, connection) {
       pattern: /^\d+_.+\.[j|t]s$/,
       wrap: fn => (knex, Promise) => {
         if (flags.raw) {
-          return Promise.resolve(fn(knex, Promise))
+          return Promise.resolve(fn(knex, Promise, flags.payload))
         } else {
-          return knex.transaction(tx => Promise.resolve(fn(tx, Promise)))
+          return knex.transaction(tx => Promise.resolve(fn(tx, Promise, flags.payload)))
         }
       }
     }


### PR DESCRIPTION
Hello!
I have provided simple method to send data to migration files. As a result, it is possible to build a generic migrations. For example if you have the same schema for multiple data sources.