### PR TITLE
Typescript migration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Global options:
   --env         Specify environment ($KNEX_ENV || $NODE_ENV || 'development')
   --raw         Disable transactions
   --verbose     Be more verbose
+  --typescript  Run in Typescript mode ($cwd/knexfile.ts lookup, Typescript compatible migration generation)
 
 As a convenience, you can skip --to flag, and just provide migration name.
 
@@ -79,7 +80,7 @@ import knexMigrate from 'knex-migrate'
 // It has following signature:
 // knexMigrate(command: String, flags: Object, progress: Function)
 
-async function run() {
+async function run () {
   // Action can be: migrate, revert. Migration is migration name. For example:
   // Doing migrate on 20170427093232_add_users
   // Doing revert on 20170427093232_add_users

--- a/src/cli.js
+++ b/src/cli.js
@@ -30,7 +30,7 @@ Global options:
   --env         Specify environment ($KNEX_ENV || $NODE_ENV || 'development')
   --raw         Disable transactions
   --verbose     Be more verbose
-  --typescript  Run in Typescript mode
+  --typescript  Run in Typescript mode ($cwd/knexfile.ts lookup, Typescript compatible migration generation)
 
 As a convenience, you can skip --to flag, and just provide migration name.
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -30,6 +30,7 @@ Global options:
   --env         Specify environment ($KNEX_ENV || $NODE_ENV || 'development')
   --raw         Disable transactions
   --verbose     Be more verbose
+  --typescript  Run in Typescript mode
 
 As a convenience, you can skip --to flag, and just provide migration name.
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ function normalizeFlags (flags) {
 
   flags.cwd = flags.cwd || process.cwd()
   flags.knexfile =
-    flags.knexfile || `knexfile.${flags.typescript ? 'ts' : 'js'}`
+    flags.knexfile || (flags.typescript ? 'knexfile.ts' : 'knexfile.js')
 
   flags.knexfile = resolve(flags.cwd, flags.knexfile)
 

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,8 @@ function normalizeFlags (flags) {
   }
 
   flags.cwd = flags.cwd || process.cwd()
-  flags.knexfile = flags.knexfile || 'knexfile.js'
+  flags.knexfile =
+    flags.knexfile || `knexfile.${flags.typescript ? 'ts' : 'js'}`
 
   flags.knexfile = resolve(flags.cwd, flags.knexfile)
 
@@ -188,19 +189,21 @@ function _ensureFolder (dir) {
 }
 
 function _generateStubTemplate (flags) {
-  const stubPath = flags.stub || resolve(__dirname, 'stub', 'js.stub')
+  const stubTemplate = flags.typescript ? 'ts.stub' : 'js.stub'
+  const stubPath = flags.stub || resolve(__dirname, 'stub', stubTemplate)
   return Promise.promisify(fs.readFile, { context: fs })(stubPath).then(stub =>
     template(stub.toString(), { variable: 'd' })
   )
 }
 
-function _writeNewMigration (dir, name, tmpl) {
-  if (name[0] === '-') name = name.slice(1)
-  const filename = yyyymmddhhmmss() + '_' + name + '.js'
+function _writeNewMigration (dir, flags, tmpl) {
+  if (flags.name[0] === '-') flags.name = flags.name.slice(1)
+  const filename =
+    yyyymmddhhmmss() + '_' + flags.name + (flags.typescript ? '.ts' : '.js')
   const variables = {}
-  if (name.indexOf('create_') === 0) {
-    console.log(name)
-    variables.tableName = name.slice(7)
+  if (flags.name.indexOf('create_') === 0) {
+    console.log(flags.name)
+    variables.tableName = flags.name.slice(7)
   }
   return Promise.promisify(fs.writeFile, { context: fs })(
     resolve(dir, filename),
@@ -253,11 +256,7 @@ async function knexMigrate (command, flags, progress) {
 
       await _ensureFolder(migrationsPath)
       const template = await _generateStubTemplate(flags)
-      const name = await _writeNewMigration(
-        migrationsPath,
-        flags.name,
-        template
-      )
+      const name = await _writeNewMigration(migrationsPath, flags, template)
 
       return relative(flags.cwd, name)
     },

--- a/src/stub/ts.stub
+++ b/src/stub/ts.stub
@@ -1,0 +1,11 @@
+import * as Knex from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+<% if (d.tableName) { %>  return knex.schema.createTable('<%= d.tableName %>', (table: Knex.CreateTableBuilder): void => {
+
+  });<% } %>
+}
+
+export async function down(knex: Knex): Promise<void> {
+<% if (d.tableName) { %>  return knex.schema.dropTable('<%= d.tableName %>');<% } %>
+}


### PR DESCRIPTION
Adds support for creating Typescript migrations. Fixes #43 

Changes add a `--typescript` flag:
* knex-migrate will look for a `knexfile.ts` file. Can still be overwritten with the `--knefile` flag
* knex-migrate will use the new `ts.stub` to generate a migration file. Can still be overwritten with the `--stub` flag