### PR TITLE
FIX Handle MSSQL missing table errors

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -5,7 +5,8 @@ function tableDoesNotExist (err, table) {
   return (
     err.code === 'ER_NO_SUCH_TABLE' ||
     new RegExp(`relation "${table}" does not exist`).test(err.message) ||
-    new RegExp(`no such table: ${table}`).test(err.message)
+    new RegExp(`no such table: ${table}`).test(err.message) ||
+    new RegExp(`Invalid object name '${table}'`).test(err.message)
   )
 }
 


### PR DESCRIPTION
Fixes #53 

If the migrations table does not exist in mssql, an error is thrown which is not correctly handled by `tableDoesNotExist`.

This matches the error thrown by the library if the table is missing.